### PR TITLE
check for process.versions.node for vue-cli compatibility

### DIFF
--- a/lib/secure-random.js
+++ b/lib/secure-random.js
@@ -17,7 +17,12 @@ if (typeof define !== 'undefined' && define.amd) { //require.js / AMD
 function secureRandom(count, options) {
   options = options || {type: 'Array'}
   //we check for process.pid to prevent browserify from tricking us
-  if (typeof process != 'undefined' && typeof process.pid == 'number') {
+  if (
+    typeof process != 'undefined'
+    && typeof process.pid == 'number'
+    && process.versions
+    && process.versions.node
+  ) {
     return nodeRandom(count, options)
   } else {
     var crypto = window.crypto || window.msCrypto


### PR DESCRIPTION
fixes #10

On vue-cli process.pid is set to 1. With current node fingerprinting
secure-random thinks it is running on node. This adds additional check
for process.versions.node and leaves previous checks intact for
compatibility.